### PR TITLE
Urls fix + some small text adjustments

### DIFF
--- a/docs/developers/basics/code-style.md
+++ b/docs/developers/basics/code-style.md
@@ -1,3 +1,3 @@
 # Code Style
 
-coming soon!
+Soon, but you can help us complete this documentation.

--- a/docs/developers/basics/creating-an-addon.md
+++ b/docs/developers/basics/creating-an-addon.md
@@ -20,7 +20,7 @@ It is generally recommended to use [Git](https://git-scm.com/) for the managemen
 ???+ abstract "Easy to Use Graphical Interface for GitHub"
     ![My Addons Folder](../../assets/images/article/github.png)
 
-Once your software is set up, you can create your first repository. Personally I do not like to create my local repository folders inside the garrysmod `addons/` folder since I prefer to have all my projects inside one folder to keep them organised. This creates a problem though, since it is really tedious to copy the contents from the `addons/` folder to your projects folder and back. [Symbolic links](https://en.wikipedia.org/wiki/Symbolic_link) are a neat solution for this. Personally on windows I use a graphical interface ([tutorial on setup and use](https://www.howtogeek.com/howto/16226/complete-guide-to-symbolic-links-symlinks-on-windows-or-linux/)), however it is up to your own preferences.
+Once your software is set up, you can create your first repository. Personally I do not like to create my local repository folders inside the garrysmod `addons/` folder since I prefer to have all my projects inside one folder to keep them organised. This creates a problem though, since it is really tedious to copy the contents from the `addons/` folder to your projects folder and back. [Symbolic links](https://en.wikipedia.org/wiki/Symbolic_link) are a neat solution for this. Personally on windows I use a graphical interface ([tutorial on setup and use](https://www.howtogeek.com/16226/complete-guide-to-symbolic-links-symlinks-on-windows-or-linux/)), however it is up to your own preferences.
 
 ### Project Structure
 

--- a/docs/developers/content-creation/creating-a-class.md
+++ b/docs/developers/content-creation/creating-a-class.md
@@ -44,7 +44,7 @@ The `classData` argument is a table that contains all the important class settin
 ???+ example "Setting the Language"
     The language for the class consists of two parts: The name and the description. At least the name should be set, but it is good practise to set the description as well.
 
-    The existing language identifiers can be found [inside these files](https://github.com/TTT-2/TTT2/tree/master/gamemodes/terrortown/gamemode/shared/lang). Currently these identifiers exist: `English`, `Deutsch`, `Русский`, `Polski`, `Italiano`
+    The existing language identifiers can be found [inside these files](https://github.com/TTT-2/TTT2/tree/master/lua/terrortown/lang). For example: `en`, `de`, `ru`, `pl`, `it` and many more.
 
     ```lua
     classData.lang = {}

--- a/docs/developers/content-creation/creating-a-hudelement.md
+++ b/docs/developers/content-creation/creating-a-hudelement.md
@@ -1,3 +1,3 @@
 # Creating a HUD Element
 
-Some Text
+Soon, but you can help us complete this documentation.

--- a/docs/developers/content-creation/creating-a-weapon.md
+++ b/docs/developers/content-creation/creating-a-weapon.md
@@ -192,5 +192,5 @@ This data is stored in a table, its the roles which can purchase it in the buy m
 
 ## Template
 
-Here is a [template weapon](https://github.com/cafelargo/TemplateSWEP) for reference to SWEP file structure.
+Here is a [template weapon](https://github.com/TomDotBat/gmod-templates/tree/master/lua/weapons/swep_weapon) for reference to SWEP file structure.
 If you want to do more than change default values to create different conventional SWEPs, view the [weapon_tttbase](https://github.com/TTT-2/TTT2/blob/master/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua) file which ttt2 uses to base its SWEPs on.

--- a/docs/developers/content-creation/creating-an-item.md
+++ b/docs/developers/content-creation/creating-an-item.md
@@ -1,3 +1,3 @@
 # Creating an Item
 
-Some Text
+Soon, but you can help us complete this documentation.

--- a/docs/developers/content-creation/language-support.md
+++ b/docs/developers/content-creation/language-support.md
@@ -45,7 +45,7 @@ To allow param translation, a keyword has to be placed inside curly brackets.
 L["ankh_health_points"] = "Health: {health} / {maxhealth}"
 ```
 
-You can check out an example [here](https://github.com/TTT-2/ttt2-role_pha/tree/master/lua/lang).
+You can check out an example [here](https://github.com/TTT-2/ttt2-role_pha/tree/master/lua/terrortown/lang).
 
 ## Using the Language Strings
 

--- a/docs/developers/content-creation/using-event-system.md
+++ b/docs/developers/content-creation/using-event-system.md
@@ -133,7 +133,7 @@ end
 ```
 
 ???+ note
-Synchronization is used in the finish-event to display the latest karma changes on roundendscreen.
+    Synchronization is used in the finish-event to display the latest karma changes on roundendscreen.
 
 ## Cancel or replace an event
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ It’s recommended to use ULX to set it up ingame, there’s an [ULX addon for T
 
 Custom roles are a very big part of TTT2. It adds the possibility to introduce new roles to the game and to change the gameplay to everybodies preferences. All of this is achieved while maintaining an easy to access framework to create new roles and a high level of compatibility.
 
-[Check out this workshop list](https://steamcommunity.com/workshop/filedetails/?id=1357745995) for a overview of roles for TTT2.
+[Check out this workshop list](https://steamcommunity.com/workshop/filedetails/?id=1737053146) for a overview of roles for TTT2.
 
 If you plan on creating your own custom role, check out [this wiki article](https://docs.ttt2.neoxult.de/developers/content-creation/creating-a-role/).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ TTT2 was the next logical step after TTT was such a massive success. It is a spi
 
 We know that TTT lives from its huge community and all its great addons. Because of this, **compatibility** is one of the highest priorities. Almost every item that works with TTT also works well with TTT2. There are a few minor exceptions though. Addons that modify the HUD, eg. Octagonal HUD, will not work with TTT2. If you plan on creating a new HUD for TTT2, you have to use the way more powerful HUD system from TTT2. Additionally addons that rely on roles may not work as intended with the newly added roles.
 
-Check out [this workshop list](https://steamcommunity.com/sharedfiles/filedetails/?id=1584725582) for addons that were reworked for TTT2.
+Check out [this workshop list](https://steamcommunity.com/sharedfiles/filedetails/?id=1379909176) for addons that were reworked for TTT2.
 
 **Hint:** You do not need addons like “Better Equipment Menu”, “Drowning Indicator” or “TTT Sprint”, because features like these are included in TTT2 by default.
 
@@ -37,7 +37,7 @@ There are a few new gamemodes based on TTT2. Click on these icons to open a list
 
 ## Configuration
 
-It’s recommended to use ULX to set it up ingame, there’s an [ULX addon for TTT2](https://steamcommunity.com/sharedfiles/filedetails/?id=1362430347). Commands for the weaponshop etc are found in [this wiki article](https://github.com/TTT-2/TTT2/wiki/Commands).
+It’s recommended to use ULX to set it up ingame, there’s an [ULX addon for TTT2](https://steamcommunity.com/sharedfiles/filedetails/?id=1362430347). Commands for the weaponshop etc. are found in [this wiki article](https://docs.ttt2.neoxult.de/).
 
 ## Feature Spotlight
 

--- a/docs/server-owners/manual-install.md
+++ b/docs/server-owners/manual-install.md
@@ -9,7 +9,7 @@ This is a guide for the most 'manual' install you can do. If you want a more aut
     - [Linux Dedicated Server Hosting](https://wiki.facepunch.com/gmod/Linux_Dedicated_Server_Hosting)
     - [Steam Game Server Accounts](https://wiki.facepunch.com/gmod/Steam_Game_Server_Accounts)
     - [Workshop Collection for Dedicated Servers](https://wiki.facepunch.com/gmod/Workshop_for_Dedicated_Servers)
-    - [Known Issues](https://developer.valvesoftware.com/wiki/SteamCMD#Known_issues)
+    - [Known Issues](https://developer.valvesoftware.com/wiki/SteamCMD#Known_Issues)
 
 ## Prerequisites
 
@@ -322,7 +322,7 @@ Next you need to get the ID of that collection and add it to your server start c
 
 ??? question "Find the ID of a collection or Addon"
     You can find the ID of any Workshop Addon/Collection at the end of the URL.
-    [https://steamcommunity.com/sharedfiles/filedetails/?id=**2052244154**](https://steamcommunity.com/sharedfiles/filedetails/?id=2052244154)
+    [https://steamcommunity.com/sharedfiles/filedetails/?id=**1379909176**](https://steamcommunity.com/sharedfiles/filedetails/?id=1379909176)
 
 ### ULX
 

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -26,7 +26,7 @@ It seems like you are using an incompatible addon on your server. We added an ad
 The sprint key is by default ++shift++, which is the same key as the team voice chat. As the team voice chat always used that key, this is still the intended default. However, if you want to change that key, you can always press ++f1++ and navigate to the `Bindings` section, where you can set a new key.
 
 ### Q3: I have an error, but it has spammed my console, so I can't copy it.
-Please send us your full log. In many cases some errors are caused by previous errors. You can get the full log when you add `-condebug` to the GarrysMod start options in Steam. The log will be saved in `GarrysMod/garrysmod/console.log`. For further information see this [discussion](https://steamcommunity.com/app/4000/discussions/1/1698293068431221842/).
+Please send us your full log. In many cases some errors are caused by previous errors. You can get the full log when you add `-condebug` to the GarrysMod start options in Steam. The log will be saved in `GarrysMod/garrysmod/console.log`.
 
 ### Q4: The server does not work, there's an error with a 'TipIndex'!
 This problem is most likely caused by another error that happened before. Please make sure to check the console / serverlog for possible errors that happened. Usually the first error is the most important one, as it will cause other things to break like a chain-reaction.


### PR DESCRIPTION
This PR fixed some dead links, adjusted some (outdated) information, fixed an issue with an note element and also removed an unnecessary codebug discussion url (which is also not available).

This fixes https://github.com/TTT-2/docs/issues/31 .
It also fixed https://github.com/TTT-2/docs/issues/12 (already fixed?).